### PR TITLE
Hotfix request replace. 

### DIFF
--- a/scrapypuppeteer/request.py
+++ b/scrapypuppeteer/request.py
@@ -47,3 +47,14 @@ class PuppeteerRequest(Request):
         self.context_id = context_id
         self.page_id = page_id
         self.close_page = close_page
+
+    def replace(self, *args, **kwargs):
+        """Create a new Request with the same attributes except for those
+        given new values.
+        """
+        for x in ['method', 'headers', 'body', 'cookies', 'meta', 'flags',
+                  'encoding', 'priority', 'dont_filter', 'callback', 'errback', 'cb_kwargs',
+                  'action', 'context_id', 'page_id', 'close_page']:
+            kwargs.setdefault(x, getattr(self, x))
+        cls = kwargs.pop('cls', self.__class__)
+        return cls(*args, **kwargs)


### PR DESCRIPTION
`TypeError: __init__() got multiple values for argument 'url'`
When using replace for request got multiple value for url keyword.