### PR TITLE
Fix: retrying context closing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Here is the list of available actions:
 - `Screenshot(options)` - take screenshot
 - `RecaptchaSolver(solve_recaptcha)` - find or solve recaptcha on page
 - `CustomJsAction(js_function)` - evaluate JS function on page
+- `CloseContext(contexts)` - close active contexts in the service
 
 Available options essentially mirror [service](https://github.com/ispras/scrapy-puppeteer-service) method parameters, which in turn mirror puppeteer API functions to some extent.
 See `scrapypuppeteer.actions` module for details.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ Here is the list of available actions:
 - `Screenshot(options)` - take screenshot
 - `RecaptchaSolver(solve_recaptcha)` - find or solve recaptcha on page
 - `CustomJsAction(js_function)` - evaluate JS function on page
-- `CloseContext(contexts)` - close active contexts in the service
 
 Available options essentially mirror [service](https://github.com/ispras/scrapy-puppeteer-service) method parameters, which in turn mirror puppeteer API functions to some extent.
 See `scrapypuppeteer.actions` module for details.
@@ -102,6 +101,9 @@ By default, only cookies are sent.
 
 You would also like to send meta with your request. By default, you are not allowed to do this
 in order to sustain backward compatibility. You can change this behaviour by setting `PUPPETEER_INCLUDE_META` to True.
+
+One your spider has done the crawling, the service middleware would close all contexts with
+`scrapypuppeteer.CloseContextRequest`. It accepts a list of all browser contexts to be closed.
 
 ## Automatic recaptcha solving
 

--- a/scrapypuppeteer/__init__.py
+++ b/scrapypuppeteer/__init__.py
@@ -1,2 +1,8 @@
 from .request import PuppeteerRequest
-from .response import *
+from .response import (
+    PuppeteerResponse,
+    PuppeteerHtmlResponse,
+    PuppeteerScreenshotResponse,
+    PuppeteerRecaptchaSolverResponse,
+    PuppeteerJsonResponse,
+)

--- a/scrapypuppeteer/__init__.py
+++ b/scrapypuppeteer/__init__.py
@@ -1,4 +1,4 @@
-from .request import PuppeteerRequest
+from .request import PuppeteerRequest, CloseContextRequest
 from .response import (
     PuppeteerResponse,
     PuppeteerHtmlResponse,

--- a/scrapypuppeteer/actions.py
+++ b/scrapypuppeteer/actions.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod, ABC
+from typing import List
 
 
 class PuppeteerServiceAction(ABC):
@@ -283,3 +284,20 @@ class CustomJsAction(PuppeteerServiceAction):
 
     def payload(self):
         return self.js_action
+
+
+class CloseContext(PuppeteerServiceAction):
+    """
+    Close contexts in the puppeteer-service.
+    """
+
+    endpoint = "close_context"
+
+    def __init__(self, contexts: List):
+        """
+        :param set contexts: Contexts to close.
+        """
+        self.contexts = contexts
+
+    def payload(self):
+        return self.contexts

--- a/scrapypuppeteer/actions.py
+++ b/scrapypuppeteer/actions.py
@@ -284,22 +284,3 @@ class CustomJsAction(PuppeteerServiceAction):
 
     def payload(self):
         return self.js_action
-
-
-class CloseContext(PuppeteerServiceAction):
-    """
-    Close contexts in the puppeteer-service.
-
-    Response for this action is PuppeteerHtmlResponse.
-    """
-
-    endpoint = "close_context"
-
-    def __init__(self, contexts: List):
-        """
-        :param list contexts: Contexts to close.
-        """
-        self.contexts = contexts
-
-    def payload(self):
-        return self.contexts

--- a/scrapypuppeteer/actions.py
+++ b/scrapypuppeteer/actions.py
@@ -289,13 +289,15 @@ class CustomJsAction(PuppeteerServiceAction):
 class CloseContext(PuppeteerServiceAction):
     """
     Close contexts in the puppeteer-service.
+
+    Response for this action is PuppeteerHtmlResponse.
     """
 
     endpoint = "close_context"
 
     def __init__(self, contexts: List):
         """
-        :param set contexts: Contexts to close.
+        :param list contexts: Contexts to close.
         """
         self.contexts = contexts
 

--- a/scrapypuppeteer/actions.py
+++ b/scrapypuppeteer/actions.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod, ABC
-from typing import List
 
 
 class PuppeteerServiceAction(ABC):

--- a/scrapypuppeteer/middleware.py
+++ b/scrapypuppeteer/middleware.py
@@ -251,7 +251,8 @@ class PuppeteerServiceDownloaderMiddleware:
             )
             dfd.addErrback(
                 lambda _: self.service_logger.log(
-                    level=logging.WARNING, msg="Could not close contexts"
+                    level=logging.WARNING,
+                    msg="Could not close contexts",
                 )
             )
             raise DontCloseSpider()

--- a/scrapypuppeteer/middleware.py
+++ b/scrapypuppeteer/middleware.py
@@ -249,6 +249,11 @@ class PuppeteerServiceDownloaderMiddleware:
                     msg=f"Successfully closed {len(request.contexts)} contexts with request {response.request}",
                 )
             )
+            dfd.addErrback(
+                lambda _: self.service_logger.log(
+                    level=logging.WARNING, msg="Could not close contexts"
+                )
+            )
             raise DontCloseSpider()
 
 

--- a/scrapypuppeteer/middleware.py
+++ b/scrapypuppeteer/middleware.py
@@ -107,9 +107,6 @@ class PuppeteerServiceDownloaderMiddleware:
         if not request.is_valid_url:
             return request.replace(
                 url=urljoin(self.service_base_url, "/close_context"),
-                method="POST",
-                headers=Headers({"Content-Type": "application/json"}),
-                body=json.dumps(request.contexts),
             )
 
     def process_puppeteer_request(self, request: PuppeteerRequest):

--- a/scrapypuppeteer/middleware.py
+++ b/scrapypuppeteer/middleware.py
@@ -179,7 +179,7 @@ class PuppeteerServiceDownloaderMiddleware:
             response_data = {
                 "html": response.text,
                 "cookies": [],
-                "contextId": None,
+                "contextId": puppeteer_request.context_id,
             }
         else:
             return response.replace(request=request)

--- a/scrapypuppeteer/request.py
+++ b/scrapypuppeteer/request.py
@@ -119,9 +119,9 @@ class CloseContextRequest(Request):
             self.is_valid_url = True
         url = kwargs.pop("url", "://")  # Incorrect url. To be replaced in middleware
 
-        kwargs["method"] = "POST",
-        kwargs["headers"] = Headers({"Content-Type": "application/json"}),
-        kwargs["body"] = json.dumps(self.contexts),
+        kwargs["method"] = "POST"
+        kwargs["headers"] = Headers({"Content-Type": "application/json"})
+        kwargs["body"] = json.dumps(self.contexts)
 
         super().__init__(url, **kwargs)
 

--- a/scrapypuppeteer/request.py
+++ b/scrapypuppeteer/request.py
@@ -1,6 +1,7 @@
+import json
 from typing import Tuple, List, Union
 
-from scrapy.http import Request
+from scrapy.http import Request, Headers
 
 from scrapypuppeteer.actions import GoTo, PuppeteerServiceAction
 
@@ -117,6 +118,11 @@ class CloseContextRequest(Request):
         if "url" in kwargs:
             self.is_valid_url = True
         url = kwargs.pop("url", "://")  # Incorrect url. To be replaced in middleware
+
+        kwargs["method"] = "POST",
+        kwargs["headers"] = Headers({"Content-Type": "application/json"}),
+        kwargs["body"] = json.dumps(self.contexts),
+
         super().__init__(url, **kwargs)
 
     def __repr__(self):

--- a/scrapypuppeteer/request.py
+++ b/scrapypuppeteer/request.py
@@ -94,3 +94,33 @@ class PuppeteerRequest(ActionRequest):
         self.page_id = page_id
         self.close_page = close_page
         self.include_headers = include_headers
+
+
+class CloseContextRequest(Request):
+    """
+    This request is used to close the browser contexts.
+
+    The response for this request is a regular Scrapy HTMLResponse.
+    """
+
+    attributes: Tuple[str, ...] = Request.attributes + ("contexts",)
+
+    def __init__(self, contexts: List, **kwargs):
+        """
+        :param contexts: list of puppeteer contexts to close.
+
+        :param kwargs: arguments of scrapy.Request.
+        """
+        self.contexts = contexts
+        self.is_valid_url = False
+
+        if "url" in kwargs:
+            self.is_valid_url = True
+        url = kwargs.pop("url", "://")  # Incorrect url. To be replaced in middleware
+        super().__init__(url, **kwargs)
+
+    def __repr__(self):
+        return f"<CLOSE CONTEXT {self.url if self.is_valid_url else 'undefined url'}>"
+
+    def __str__(self):
+        return self.__repr__()

--- a/scrapypuppeteer/response.py
+++ b/scrapypuppeteer/response.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Tuple, Union
 
 from scrapy.exceptions import ScrapyDeprecationWarning
@@ -5,8 +6,6 @@ from scrapy.http import TextResponse
 
 from scrapypuppeteer import PuppeteerRequest
 from scrapypuppeteer.actions import GoTo, PuppeteerServiceAction
-
-import warnings
 
 
 class PuppeteerResponse(TextResponse):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as readme:
 
 setup(
     name="scrapy-puppeteer-client",
-    version="0.1.5",
+    version="0.2.0",
     description="A library to use Puppeteer-managed browser in Scrapy spiders",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as readme:
 
 setup(
     name="scrapy-puppeteer-client",
-    version="0.2.0",
+    version="0.3.0",
     description="A library to use Puppeteer-managed browser in Scrapy spiders",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# Description

When the `PuppeteerServiceMiddleware` is failed with "retry" codes, it is not able to retry it.
I fixed the problem, added `CloseContext` action and added some logging to this.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested it by modifying the ExpressJS server in `close_context` endpoint:
```
if (Math.random() > 0.45) {  // Just some random number
    res.status(500);
    return next();
}
```

Then used my local spider to check if everything is fine and `retryable`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings