### PR TITLE
Json to Html converse

### DIFF
--- a/scrapypuppeteer/middleware.py
+++ b/scrapypuppeteer/middleware.py
@@ -247,13 +247,19 @@ class PuppeteerServiceDownloaderMiddleware:
             def handle_close_contexts_result(result):
                 if isinstance(result, Response):
                     if result.status == 200:
-                        self.service_logger.debug(f"Successfully closed {len(request.contexts)} "
-                                                  f"contexts with request {result.request}")
+                        self.service_logger.debug(
+                            f"Successfully closed {len(request.contexts)} "
+                            f"contexts with request {result.request}"
+                        )
                     else:
-                        self.service_logger.warning(f"Could not close contexts: {result.text}")
+                        self.service_logger.warning(
+                            f"Could not close contexts: {result.text}"
+                        )
                 elif isinstance(result, Failure):
-                    self.service_logger.warning(f"Could not close contexts: {result.value}",
-                                                exc_info=failure_to_exc_info(result))
+                    self.service_logger.warning(
+                        f"Could not close contexts: {result.value}",
+                        exc_info=failure_to_exc_info(result),
+                    )
 
             dfd = self.crawler.engine.download(request)
             dfd.addBoth(handle_close_contexts_result)

--- a/scrapypuppeteer/response.py
+++ b/scrapypuppeteer/response.py
@@ -140,7 +140,10 @@ class PuppeteerJsonResponse(PuppeteerResponse):
         for attr in PuppeteerResponse.attributes:
             kwargs[attr] = getattr(self, attr)
         kwargs["html"] = self.data["html"]
+        kwargs["body"] = kwargs["html"]
         kwargs["cookies"] = self.data["cookies"]
+        kwargs["headers"].update({"Content-Type": ["text/html"]})
+        kwargs["encoding"] = "utf-8"
 
         return PuppeteerHtmlResponse(**kwargs)
 

--- a/scrapypuppeteer/response.py
+++ b/scrapypuppeteer/response.py
@@ -122,6 +122,29 @@ class PuppeteerJsonResponse(PuppeteerResponse):
         self.data = data
         super().__init__(url, puppeteer_request, context_id, page_id, **kwargs)
 
+    def to_html(self) -> PuppeteerHtmlResponse:
+        """
+        Tries to converge a PuppeteerJsonResponse to a PuppeteerHtmlResponse.
+        For this self.data must be dict.
+        Then self.data must have "html" key with a string containing a page content
+        and "cookies" key with a list of cookies or None.
+
+        If the .data property does not have at least 1 argument the error is raised.
+        """
+        if not isinstance(self.data, dict):
+            raise TypeError(
+                "PuppeteerJsonResponse's .data property must be a dict"
+                "to converse it to a PuppeteerHtmlResponse."
+            )
+
+        kwargs = dict()
+        for attr in PuppeteerResponse.attributes:
+            kwargs[attr] = getattr(self, attr)
+        kwargs["html"] = self.data["html"]
+        kwargs["cookies"] = self.data["cookies"]
+
+        return PuppeteerHtmlResponse(**kwargs)
+
 
 class PuppeteerRecaptchaSolverResponse(PuppeteerJsonResponse, PuppeteerHtmlResponse):
     """

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as readme:
 
 setup(
     name="scrapy-puppeteer-client",
-    version="0.3.0",
+    version="0.3.1",
     description="A library to use Puppeteer-managed browser in Scrapy spiders",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# Description

Sometimes scrapers use CustomJsAction to change state of a page but then they are not able to use Scrapy selectors even with `html` and `cookies` received from the service.
The implemented `to_html` method of `PuppeteerJsonResponse` solves the problem.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested it with several local spiders if everything worked fine. And implemented 1 more to check the implemented method

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings