### PR TITLE
Allow top-level import of actions

### DIFF
--- a/scrapypuppeteer/__init__.py
+++ b/scrapypuppeteer/__init__.py
@@ -1,3 +1,16 @@
+from .actions import (
+    PuppeteerServiceAction,
+    GoTo,
+    GoForward,
+    GoBack,
+    Click,
+    Scroll,
+    Screenshot,
+    Har,
+    FillForm,
+    RecaptchaSolver,
+    CustomJsAction,
+)
 from .request import PuppeteerRequest, CloseContextRequest
 from .response import (
     PuppeteerResponse,


### PR DESCRIPTION
# Title

Allow to import actions from scrapypuppeteer package

# Description

Compatibility fix for crawlers that used `from scrapypuppeteer import GoTo`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
